### PR TITLE
Updated avr-gcc in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,15 @@ RUN apt-get update  \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -L https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/SHA256SUMS -o SHA256SUMS
-RUN curl -L https://github.com/ZakKemble/avr-gcc-build/releases/download/v14.1.0-1/avr-gcc-14.1.0-x64-linux.tar.bz2 \
-    -o avr-gcc-14.1.0-x64-linux.tar.bz2
+RUN curl -L https://github.com/ZakKemble/avr-gcc-build/releases/download/v15.1.0-1/SHA256SUMS -o SHA256SUMS
+RUN curl -L https://github.com/ZakKemble/avr-gcc-build/releases/download/v15.1.0-1/avr-gcc-15.1.0-x64-linux.tar.bz2 \
+    -o avr-gcc-15.1.0-x64-linux.tar.bz2
 RUN sha256sum --ignore-missing -c SHA256SUMS
 
 
 RUN mkdir /avr-toolchain/
-RUN tar -xf avr-gcc-14.1.0-x64-linux.tar.bz2 -C /avr-toolchain
-RUN rm avr-gcc-14.1.0-x64-linux.tar.bz2
+RUN tar -xf avr-gcc-15.1.0-x64-linux.tar.bz2 -C /avr-toolchain
+RUN rm avr-gcc-15.1.0-x64-linux.tar.bz2
 RUN rm SHA256SUMS
 
-ENV PATH="$PATH:/avr-toolchain/avr-gcc-14.1.0-x64-linux/bin"
+ENV PATH="$PATH:/avr-toolchain/avr-gcc-15.1.0-x64-linux/bin"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,47 @@
 # Nextag-Embedded-Platform
 
 ## How to build
-Install gcc-avr 13.2 to path.
-Install simavr to path
+- Clone repository with submodules
+- Install avr-gcc 15.1 (add to PATH). Ensure binutils and avr-libc are present.
+- Install CMake and Ninja (or use the Docker flow below).
+- Install simavr (add to PATH).
+- Configure CMake using:
+```sh
+cmake -G Ninja -S . -B build/Release -DCMAKE_BUILD_TYPE=Release -DNEXTAG_EMBEDDED_PLATFORM_CONFIGURE_AS_UNO=ON
+```
+- Build using:
+```sh
+ninja -C build/Release
+```
+- Run tests using:
+```sh
+ctest --test-dir build/Release -C Release --output-on-failure
+```
+
+## How to build using docker
+Alternatively you can use docker to build Nextag Embedded Platform. The docker container is set up to include the correct 
+version of the avr toolchain and simavr. The docker toolchain can be used as follows (the commands assume execution from the root directory from bash):
+
+- Clone repository with submodules
+- Build the toolchain docker container using: `docker build -t avr-gcc-toolchain:latest -f Dockerfile . --platform=linux/amd64`
+- Configure CMake using: 
+```bash
+docker run --rm -v $PWD:/Nextag-Embedded-Platform:z avr-gcc-toolchain                     \
+  cmake -G Ninja -S /Nextag-Embedded-Platform/ -B /Nextag-Embedded-Platform/build/Release \
+  -DCMAKE_BUILD_TYPE=Release -DNEXTAG_EMBEDDED_PLATFORM_CONFIGURE_AS_UNO=ON
+```
+
+- Run the build using: 
+```sh
+docker run --rm -v $PWD:/Nextag-Embedded-Platform:z avr-gcc-toolchain                     \
+  ninja -C /Nextag-Embedded-Platform/build/Release
+```
+
+- Run the tests using: 
+```sh
+docker run --rm -v $PWD:/Nextag-Embedded-Platform:z avr-gcc-toolchain                     \
+  ctest --test-dir /Nextag-Embedded-Platform/build/Release --output-on-failure
+```
 
 ## Toolchain
 The toolchain is based on [mkleemann/cmake-avr](https://github.com/mkleemann/cmake-avr)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Docker-based build workflow for configuring, building, and testing in a containerized toolchain.

* **Chores**
  * Updated AVR GCC toolchain to v15.1.0 and adjusted environment paths to use the new toolchain.
  * Base image remains Ubuntu 24.04; rebuild recommended due to toolchain update.

* **Documentation**
  * README rewritten with a full, submodule-aware build flow, explicit CMake/Ninja commands, UNO-enabled configuration, and Docker usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->