### PR TITLE
Moved static strings in testing framework from SRAM to flash

### DIFF
--- a/tests/drivers/digital_io/main.cpp
+++ b/tests/drivers/digital_io/main.cpp
@@ -3,15 +3,13 @@
  * Licensed using the MIT license
  */
 
-#include "nextag_test/serial.h"
-
-
 #include <nextag_test/nextag_test.h>
 
 #include <NextagEmbeddedPlatform/drivers/digital_io.h>
 
-#include <avr/sleep.h>
 #include <unity.h>
+
+#include <avr/sleep.h>
 
 using namespace NextagEmbeddedPlatform::Drivers;
 

--- a/tests/nextag_test/include/nextag_test/nextag_test.h
+++ b/tests/nextag_test/include/nextag_test/nextag_test.h
@@ -5,27 +5,30 @@
 
 #pragma once
 
+#include "nextag_test/serial.h"
 #include "nextag_test/test.h"
 #include "nextag_test/test_collection.h"
+
+#include <avr/pgmspace.h>
 
 #define CONCAT(a, b)              a##b
 #define CONCAT_TEST_NAME(a, b, c) CONCAT(a##b, c)
 
-#define TEST_IMPL(TestSuite, TestName, DisplayName)                              \
-    class TestName : public TestSuite                                            \
-    {                                                                            \
-    public:                                                                      \
-        TestName()                                                               \
-        {                                                                        \
-            NextagTest::TestCollection::addTest(this);                           \
-        }                                                                        \
-        void operator()() override;                                              \
-    };                                                                           \
-    static TestName CONCAT(test_, TestName);                                     \
-    static const auto CONCAT(initializedTest_, TestName) = [](TestName & test) { \
-        test.setMetaData(#TestSuite "\\" #DisplayName, __FILE__, __LINE__);      \
-        return true;                                                             \
-    }(CONCAT(test_, TestName));                                                  \
+#define TEST_IMPL(TestSuite, TestName, DisplayName)                                     \
+    class TestName : public TestSuite                                                   \
+    {                                                                                   \
+    public:                                                                             \
+        TestName()                                                                      \
+        {                                                                               \
+            NextagTest::TestCollection::addTest(this);                                  \
+        }                                                                               \
+        void operator()() override;                                                     \
+    };                                                                                  \
+    static TestName CONCAT(test_, TestName);                                            \
+    static const auto CONCAT(initializedTest_, TestName) = [](TestName & test) {        \
+        test.setMetaData(PSTR(#TestSuite "\\" #DisplayName), PSTR(__FILE__), __LINE__); \
+        return true;                                                                    \
+    }(CONCAT(test_, TestName));                                                         \
     void TestName::operator()()
 
 #define TEST_F(TestSuite, TestName) TEST_IMPL(TestSuite, CONCAT_TEST_NAME(Test_, TestName, __COUNTER__), TestName)

--- a/tests/nextag_test/include/nextag_test/nextag_test.h
+++ b/tests/nextag_test/include/nextag_test/nextag_test.h
@@ -14,21 +14,21 @@
 #define CONCAT(a, b)              a##b
 #define CONCAT_TEST_NAME(a, b, c) CONCAT(a##b, c)
 
-#define TEST_IMPL(TestSuite, TestName, DisplayName)                                     \
-    class TestName : public TestSuite                                                   \
-    {                                                                                   \
-    public:                                                                             \
-        TestName()                                                                      \
-        {                                                                               \
-            NextagTest::TestCollection::addTest(this);                                  \
-        }                                                                               \
-        void operator()() override;                                                     \
-    };                                                                                  \
-    static TestName CONCAT(test_, TestName);                                            \
-    static const auto CONCAT(initializedTest_, TestName) = [](TestName & test) {        \
-        test.setMetaData(PSTR(#TestSuite "\\" #DisplayName), PSTR(__FILE__), __LINE__); \
-        return true;                                                                    \
-    }(CONCAT(test_, TestName));                                                         \
+#define TEST_IMPL(TestSuite, TestName, DisplayName)                                          \
+    class TestName : public TestSuite                                                        \
+    {                                                                                        \
+    public:                                                                                  \
+        TestName()                                                                           \
+        {                                                                                    \
+            NextagTest::TestCollection::addTest(this);                                       \
+        }                                                                                    \
+        void operator()() override;                                                          \
+    };                                                                                       \
+    static TestName CONCAT(test_, TestName);                                                 \
+    static const auto CONCAT(initializedTest_, TestName) = [](TestName & test) {             \
+        test.setMetaData(PSTR(#TestSuite "\\" #DisplayName), PSTR(__FILE_NAME__), __LINE__); \
+        return true;                                                                         \
+    }(CONCAT(test_, TestName));                                                              \
     void TestName::operator()()
 
 #define TEST_F(TestSuite, TestName) TEST_IMPL(TestSuite, CONCAT_TEST_NAME(Test_, TestName, __COUNTER__), TestName)

--- a/tests/nextag_test/include/nextag_test/test_list.h
+++ b/tests/nextag_test/include/nextag_test/test_list.h
@@ -4,6 +4,7 @@
  */
 
 #pragma once
+
 #include "test.h"
 
 #include <stdio.h>

--- a/tests/nextag_test/src/test_collection.cpp
+++ b/tests/nextag_test/src/test_collection.cpp
@@ -17,15 +17,15 @@ static Test * testToExecute = nullptr;
 
 void TestCollection::runAllTests()
 {
-    UnityBegin("");
+    UnityBegin(PSTR("N/A"));
     for (size_t i = 0; i < m_testList.size(); i++)
     {
         auto & test = *m_testList.at(i);
-        char testFileBuffer[128] = {0};
-        char testNameBuffer[123] = {0};
+        char testFileBuffer[64] = {0};
+        char testNameBuffer[128] = {0};
 
-        strcpy_P(testFileBuffer, test.file());
-        strcpy_P(testNameBuffer, test.name());
+        strncpy_P(testFileBuffer, test.file(), 63);
+        strncpy_P(testNameBuffer, test.name(), 127);
 
         UnitySetTestFile(testFileBuffer);
         testToExecute = &test;

--- a/tests/nextag_test/src/test_collection.cpp
+++ b/tests/nextag_test/src/test_collection.cpp
@@ -24,8 +24,8 @@ void TestCollection::runAllTests()
         char testFileBuffer[64] = {0};
         char testNameBuffer[128] = {0};
 
-        strncpy_P(testFileBuffer, test.file(), 63);
-        strncpy_P(testNameBuffer, test.name(), 127);
+        strncpy_P(testFileBuffer, test.file(), sizeof(testFileBuffer) - 1);
+        strncpy_P(testNameBuffer, test.name(), sizeof(testNameBuffer) - 1);
 
         UnitySetTestFile(testFileBuffer);
         testToExecute = &test;

--- a/tests/nextag_test/src/test_collection.cpp
+++ b/tests/nextag_test/src/test_collection.cpp
@@ -5,6 +5,7 @@
 
 #include "nextag_test/test_collection.h"
 
+#include <avr/pgmspace.h>
 #include <unity.h>
 
 namespace NextagTest
@@ -16,14 +17,23 @@ static Test * testToExecute = nullptr;
 
 void TestCollection::runAllTests()
 {
-    UnityBegin(__FILE__);
+    UnityBegin("");
     for (size_t i = 0; i < m_testList.size(); i++)
     {
         auto & test = *m_testList.at(i);
-        UnitySetTestFile(test.file());
+        char testFileBuffer[128] = {0};
+        char testNameBuffer[123] = {0};
+
+        strcpy_P(testFileBuffer, test.file());
+        strcpy_P(testNameBuffer, test.name());
+
+        UnitySetTestFile(testFileBuffer);
         testToExecute = &test;
         test.setUp();
-        UnityDefaultTestRun([]() { testToExecute->operator()(); }, test.name(), test.line());
+        UnityDefaultTestRun([]() {
+            testToExecute->operator()();
+        },
+                            testNameBuffer, test.line());
         test.tearDown();
     }
     UnityEnd();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test harness now stores metadata in program memory and copies it to RAM at runtime (PSTR/PROGMEM), reducing RAM usage and ensuring reliable test metadata during execution.
  * Test runner adjusted to pass buffered metadata when invoking individual tests.

* **Chores**
  * Reorganized and cleaned up header includes and include ordering for clearer structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->